### PR TITLE
Enable nested hardware virtualizations so Proxmox KVM VMs work.

### DIFF
--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure('2') do |config|
     vb.linked_clone = true
     vb.memory = 2048
     vb.cpus = 4
+    vb.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
   end
   ip = '10.10.10.2'
   config.vm.network :private_network, ip: ip, auto_config: false


### PR DESCRIPTION
Requires VirtualBox 6.1 or later.

This could probably be enabled in the Packer template itself but only relatively recent VirtualBox versions (6.1 and later) support this option, so I placed the `vboxmanage modifyvm` command in the `example/Vagrantfile` to be safe.