### PR TITLE
The default size of 15G is not sufficient - pve-root is 3.5G.

### DIFF
--- a/proxmox-ve.json
+++ b/proxmox-ve.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "disk_size": "15375",
+    "disk_size": "20480",
     "iso_url": "http://download.proxmox.com/iso/proxmox-ve_7.0-1.iso",
     "iso_checksum": "sha256:ae38bcb5ecc9aa97f6b13b89689fc4e876f9535f738bc0be4ffa4924274f25d9",
     "hyperv_switch_name": "{{env `HYPERV_SWITCH_NAME`}}",


### PR DESCRIPTION
The default size of 15G is not sufficient - pve-root is 3.5G.

```
root@pve:~# apt-get install -y rsync sshfs
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
rsync is already the newest version (3.2.3-4).
sshfs is already the newest version (3.7.1+repack-2).
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up initramfs-tools (0.140) ...
update-initramfs: deferring update (trigger activated)
Processing triggers for initramfs-tools (0.140) ...
update-initramfs: Generating /boot/initrd.img-5.11.22-1-pve
cpio: write error: No space left on device
E: mkinitramfs failure cpio 2
update-initramfs: failed for /boot/initrd.img-5.11.22-1-pve with 1.
dpkg: error processing package initramfs-tools (--configure):
    installed initramfs-tools package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
    initramfs-tools
E: Sub-process /usr/bin/dpkg returned an error code (1)
root@pve:~# df -h
Filesystem            Size  Used Avail Use% Mounted on
udev                  959M     0  959M   0% /dev
tmpfs                 198M  760K  198M   1% /run
/dev/mapper/pve-root  3.4G  3.1G  114M  97% /
tmpfs                 990M   25M  965M   3% /dev/shm
tmpfs                 5.0M     0  5.0M   0% /run/lock
/dev/fuse             128M   16K  128M   1% /etc/pve
tmpfs                 198M     0  198M   0% /run/user/0
```

Also:
```
root@pve:/var/log# lsblk
NAME               MAJ:MIN RM    SIZE RO TYPE MOUNTPOINT
sda                  8:0    0     15G  0 disk
├─sda1               8:1    0   1007K  0 part
├─sda2               8:2    0    512M  0 part
└─sda3               8:3    0   14.5G  0 part
    ├─pve-swap       253:0    0    1.8G  0 lvm  [SWAP]
    ├─pve-root       253:1    0    3.5G  0 lvm  /
    ├─pve-data_tmeta 253:2    0      1G  0 lvm
    │ └─pve-data     253:4    0    5.5G  0 lvm
    └─pve-data_tdata 253:3    0    5.5G  0 lvm
    └─pve-data     253:4    0    5.5G  0 lvm
sr0                 11:0    1 1015.6M  0 rom
sr1                 11:1    1   58.2M  0 rom
```

I tried cleaning it up, but it just isn't enough.
Some time can be spent on https://wiki.debian.org/ReduceDebian, but it will take some effort and I don't know whether the author wants that.