### PR TITLE
Enhance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This builds an up-to-date [Proxmox VE](https://www.proxmox.com/en/proxmox-ve) Vagrant Base Box.
 
-Currently this targets Proxmox VE 7.0.
+Currently this targets Proxmox VE 7.1.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Create the base box:
 make build-libvirt # or build-virtualbox
 ```
 
+Add the base box as suggested in make output:
+
+```bash
+vagrant box add -f proxmox-ve-amd64 proxmox-ve-amd64-libvirt.box # or proxmox-ve-amd64-virtualbox.box
+```
+
 Start the example vagrant environment with:
 
 ```bash
@@ -62,6 +68,12 @@ Create the base box:
 
 ```bash
 make build-hyperv
+```
+
+Add the base box as suggested in make output:
+
+```bash
+vagrant box add -f proxmox-ve-amd64 proxmox-ve-amd64-hyperv.box
 ```
 
 Start the example vagrant environment with:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ corresponding answers.
 
 | step                              | boot_command                                          |
 |----------------------------------:|-------------------------------------------------------|
-| select "Intall Proxmox VE"        | `<enter>`                                             |
+| select "Install Proxmox VE"       | `<enter>`                                             |
 | wait for boot                     | `<wait1m>`                                            |
 | agree license                     | `<enter><wait>`                                       |
 | target disk                       | `<enter><wait>`                                       |


### PR DESCRIPTION
* fix version 7.0 (old) to 7.1 (current value in `proxmox-ve.json`)
* fix `boot_command` step name `Intall Proxmox VE` to `In**s**tall Proxmox VE`
* document to execute `vagrant box add` as it might get overlooked in the make output