### PR TITLE
Support alternative packer output dir to reduce disk wear

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-hyperv: proxmox-ve-amd64-hyperv.box
 
 proxmox-ve-amd64-libvirt.box: provisioners/*.sh proxmox-ve.json Vagrantfile.template
 	rm -f $@
-	PACKER_KEY_INTERVAL=10ms CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
+	PACKER_OUTPUT_BASE_DIR=$${PACKER_OUTPUT_BASE_DIR:-.} PACKER_KEY_INTERVAL=10ms CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
 		packer build -only=proxmox-ve-amd64-libvirt -on-error=abort -timestamp-ui proxmox-ve.json
 	@echo Box successfully built!
 	@echo to add it to vagrant run:
@@ -16,7 +16,7 @@ proxmox-ve-amd64-libvirt.box: provisioners/*.sh proxmox-ve.json Vagrantfile.temp
 
 proxmox-ve-uefi-amd64-libvirt.box: provisioners/*.sh proxmox-ve.json Vagrantfile-uefi.template
 	rm -f $@
-	PACKER_KEY_INTERVAL=10ms CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
+	PACKER_OUTPUT_BASE_DIR=$${PACKER_OUTPUT_BASE_DIR:-.} PACKER_KEY_INTERVAL=10ms CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
 		packer build -only=proxmox-ve-uefi-amd64-libvirt -on-error=abort -timestamp-ui proxmox-ve.json
 	@echo Box successfully built!
 	@echo to add it to vagrant run:
@@ -24,7 +24,7 @@ proxmox-ve-uefi-amd64-libvirt.box: provisioners/*.sh proxmox-ve.json Vagrantfile
 
 proxmox-ve-amd64-virtualbox.box: provisioners/*.sh proxmox-ve.json Vagrantfile.template
 	rm -f $@
-	CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
+	PACKER_OUTPUT_BASE_DIR=$${PACKER_OUTPUT_BASE_DIR:-.} CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
 		packer build -only=proxmox-ve-amd64-virtualbox -on-error=abort -timestamp-ui proxmox-ve.json
 	@echo Box successfully built!
 	@echo to add it to vagrant run:
@@ -33,13 +33,13 @@ proxmox-ve-amd64-virtualbox.box: provisioners/*.sh proxmox-ve.json Vagrantfile.t
 proxmox-ve-amd64-hyperv.box: provisioners/*.sh proxmox-ve.json Vagrantfile.template
 	rm -f $@
 	mkdir -p tmp
-	CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
+	PACKER_OUTPUT_BASE_DIR=$${PACKER_OUTPUT_BASE_DIR:-.} CHECKPOINT_DISABLE=1 PACKER_LOG=1 PACKER_LOG_PATH=$@.log \
 		packer build -only=proxmox-ve-amd64-hyperv -on-error=abort -timestamp-ui proxmox-ve.json
 	@echo Box successfully built!
 	@echo to add it to vagrant run:
 	@echo vagrant box add -f proxmox-ve-amd64 $@
 
 clean:
-	rm -rf packer_cache output-proxmox-ve*
+	rm -rf packer_cache $${PACKER_OUTPUT_BASE_DIR:-.}/output-proxmox-ve*
 
 .PHONY: help build-libvirt build-virtualbox build-hyperv clean

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ vagrant up --provider=hyperv
 
 ## Packer build performance options
 
-To improve build performance you can use one or all of the following options.
+To improve the build performance you can use the following options.
 
 ### Accelerate build time with Apt Caching Proxy
 
@@ -100,11 +100,11 @@ Example:
 APT_CACHE_HOST=10.10.10.100 make build-libvirt
 ```
 
-### Decrease disk wear by using temporary file storage
+### Decrease disk wear by using temporary memory file-system
 
 To decrease disk wear (and potentially reduce io times),
-you can use `/dev/shm` as `output_directory` for Packer builders.
-Your system has to have enough available memory to store the created virtual machine.
+you can use `/dev/shm` (temporary memory file-system) as `output_directory` for Packer builders.
+Your system must have enough available memory to store the created virtual machine.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ cd example
 vagrant up --provider=hyperv
 ```
 
-## Accelerate build time with Apt Caching Proxy
+## Packer build performance options
+
+To improve build performance you can use one or all of the following options.
+
+### Accelerate build time with Apt Caching Proxy
 
 To speed up package downloads, you can specify an apt caching proxy 
 (e.g. [apt-cacher-ng](https://www.unix-ag.uni-kl.de/~bloch/acng/))
@@ -95,6 +99,20 @@ Example:
 ```bash
 APT_CACHE_HOST=10.10.10.100 make build-libvirt
 ```
+
+### Decrease disk wear by using temporary file storage
+
+To decrease disk wear (and potentially reduce io times),
+you can use `/dev/shm` as `output_directory` for Packer builders.
+Your system has to have enough available memory to store the created virtual machine.
+
+Example:
+
+```bash
+PACKER_OUTPUT_BASE_DIR=/dev/shm make build-libvirt
+```
+
+Remember to also define `PACKER_OUTPUT_BASE_DIR` when you run `make clean` afterwards.
 
 # Packer boot_command
 

--- a/proxmox-ve.json
+++ b/proxmox-ve.json
@@ -12,7 +12,6 @@
   "builders": [
     {
       "name": "proxmox-ve-amd64-libvirt",
-      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-amd64-libvirt",
       "type": "qemu",
       "accelerator": "kvm",
       "cpus": 2,
@@ -28,6 +27,7 @@
       "disk_discard": "unmap",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
+      "output_directory": "{{user `output_base_dir`}}/output-{{build_name}}",
       "ssh_username": "root",
       "ssh_password": "vagrant",
       "ssh_timeout": "60m",
@@ -60,7 +60,6 @@
     },
     {
       "name": "proxmox-ve-uefi-amd64-libvirt",
-      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-uefi-amd64-libvirt",
       "type": "qemu",
       "accelerator": "kvm",
       "cpus": 2,
@@ -77,6 +76,7 @@
       "disk_discard": "unmap",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
+      "output_directory": "{{user `output_base_dir`}}/output-{{build_name}}",
       "ssh_username": "root",
       "ssh_password": "vagrant",
       "ssh_timeout": "60m",
@@ -109,7 +109,6 @@
     },
     {
       "name": "proxmox-ve-amd64-virtualbox",
-      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-amd64-virtualbox",
       "type": "virtualbox-iso",
       "guest_os_type": "Debian_64",
       "guest_additions_mode": "attach",
@@ -134,6 +133,7 @@
       "hard_drive_discard": true,
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
+      "output_directory": "{{user `output_base_dir`}}/output-{{build_name}}",
       "ssh_username": "root",
       "ssh_password": "vagrant",
       "ssh_timeout": "60m",
@@ -166,7 +166,6 @@
     },
     {
       "name": "proxmox-ve-amd64-hyperv",
-      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-amd64-hyperv",
       "type": "hyperv-iso",
       "temp_path": "tmp",
       "headless": true,
@@ -180,6 +179,7 @@
       "disk_size": "{{user `disk_size`}}",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
+      "output_directory": "{{user `output_base_dir`}}/output-{{build_name}}",
       "ssh_username": "root",
       "ssh_password": "vagrant",
       "ssh_timeout": "60m",

--- a/proxmox-ve.json
+++ b/proxmox-ve.json
@@ -6,11 +6,13 @@
     "hyperv_switch_name": "{{env `HYPERV_SWITCH_NAME`}}",
     "hyperv_vlan_id": "{{env `HYPERV_VLAN_ID`}}",
     "apt_cache_host": "{{env `APT_CACHE_HOST`}}",
-    "apt_cache_port": "{{env `APT_CACHE_PORT`}}"
+    "apt_cache_port": "{{env `APT_CACHE_PORT`}}",
+    "output_base_dir": "{{env `PACKER_OUTPUT_BASE_DIR`}}"
   },
   "builders": [
     {
       "name": "proxmox-ve-amd64-libvirt",
+      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-amd64-libvirt",
       "type": "qemu",
       "accelerator": "kvm",
       "cpus": 2,
@@ -58,6 +60,7 @@
     },
     {
       "name": "proxmox-ve-uefi-amd64-libvirt",
+      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-uefi-amd64-libvirt",
       "type": "qemu",
       "accelerator": "kvm",
       "cpus": 2,
@@ -106,6 +109,7 @@
     },
     {
       "name": "proxmox-ve-amd64-virtualbox",
+      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-amd64-virtualbox",
       "type": "virtualbox-iso",
       "guest_os_type": "Debian_64",
       "guest_additions_mode": "attach",
@@ -162,6 +166,7 @@
     },
     {
       "name": "proxmox-ve-amd64-hyperv",
+      "output_directory": "{{user `output_base_dir`}}/output-proxmox-ve-amd64-hyperv",
       "type": "hyperv-iso",
       "temp_path": "tmp",
       "headless": true,


### PR DESCRIPTION
## Change

To decrease disk wear (and potentially reduce io times), you can use `/dev/shm` as `output_directory` for Packer builders.
Your system has to have enough available memory to store the created virtual machine.

## Tests

As of today you need about 5 GB of available memory and you can reduce written disk data from ~11 GB to ~1 GB per build.

* Using working directory:
   ```bash
   $ sudo awk '/nvme0n1 / {print $3"\t"$10 / 2 / 1024 / 1024" GB"}' /proc/diskstats
   nvme0n1	87.346 GB

   $ make build-libvirt
   [...]

   $ sudo awk '/nvme0n1 / {print $3"\t"$10 / 2 / 1024 / 1024" GB"}' /proc/diskstats
   nvme0n1	98.043 GB
   ```
   Result: ~11 GB written

* Using `/dev/shm`:
   ```bash
   $ sudo awk '/nvme0n1 / {print $3"\t"$10 / 2 / 1024 / 1024" GB"}' /proc/diskstats
   nvme0n1	84.311 GB

   $ PACKER_OUTPUT_BASE_DIR=/dev/shm make build-libvirt
   [...]

   $ sudo awk '/nvme0n1 / {print $3"\t"$10 / 2 / 1024 / 1024" GB"}' /proc/diskstats
   nvme0n1	85.190 GB
   ```
   Result: ~1 GB written

Versions used:

```bash
$ packer --version
1.8.3

$ qemu-system-x86_64 --version
QEMU emulator version 6.2.0 (Debian 1:6.2+dfsg-2ubuntu6.3)
```

## Disclaimer

Not tested with either Virtualbox or Hyperv as I only have a Libvirt setup.